### PR TITLE
Help GitHub to identify the MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-Vortex
 MIT License
 
 Copyright (c) 2024 Paul Hudson.


### PR DESCRIPTION
The Swift Package Index is currently showing an "Unknown license" for this package because the word "Vortex" at the top upsets GitHub's license detection code which is very strict.

Removing this one word makes GitHub happy, and a couple of hours later that will make the Swift Package Index happy when we also notice the change! I've tested the detection code on my branch here and it works:

![Screenshot 2024-02-09 at 18 06 52@2x](https://github.com/twostraws/Vortex/assets/5180/de4a9185-a573-4ce6-a0af-b19325c39104)
