### PR TITLE
Fix VortexViewReader not finding particle system sometimes.

### DIFF
--- a/Sources/Vortex/Views/VortexSystemPreferenceKey.swift
+++ b/Sources/Vortex/Views/VortexSystemPreferenceKey.swift
@@ -9,5 +9,7 @@ import SwiftUI
 
 /// Used by VortexViewReader to track the nearest particle system it contains.
 struct VortexSystemPreferenceKey: PreferenceKey {
-    static func reduce(value: inout VortexSystem?, nextValue: () -> VortexSystem?) { }
+    static func reduce(value: inout VortexSystem?, nextValue: () -> VortexSystem?) {
+        value = nextValue()
+    }
 }


### PR DESCRIPTION
The Vortex System wasn't found for some view combinations

VortexViewReader { proxy in
  ZStack {
    ScrollView {
      ...
    }              
    VortexView(.confetti) {
       ..
    }
  }
}

never seemed to work for example.