### PR TITLE
Introducing VortexSystem.Settings

### DIFF
--- a/Sources/Vortex/Presets/Confetti.swift
+++ b/Sources/Vortex/Presets/Confetti.swift
@@ -9,21 +9,25 @@ import SwiftUI
 
 extension VortexSystem {
     /// A built-in effect that creates confetti only when a burst is triggered.
-    /// Relies on "square" and "circle" tags being present – using `Rectangle`
+    /// Relies on "confetti" and "circle" tags being present – using `Rectangle`
     /// and `Circle` with frames of 16x16 works well.
-    public static let confetti: VortexSystem = {
-        VortexSystem(
-            tags: ["square", "circle"],
-            birthRate: 0,
-            lifespan: 4,
-            speed: 0.5,
-            speedVariation: 0.5,
-            angleRange: .degrees(90),
-            acceleration: [0, 1],
-            angularSpeedVariation: [4, 4, 4],
-            colors: .random(.white, .red, .green, .blue, .pink, .orange, .cyan),
-            size: 0.5,
-            sizeVariation: 0.5
-        )
-    }()
+    /// This declaration is deprecated. A VortexView should be invoked with a VortexSystem.Settings struct directly. See the example below.
+    public static let confetti = VortexSystem(settings: .confetti)
+}
+
+extension VortexSystem.Settings {
+    /// A built-in effect that creates confetti only when a burst is triggered.
+    public static let confetti = VortexSystem.Settings() { settings in
+        settings.tags = ["confetti", "circle"]
+        settings.birthRate = 0
+        settings.lifespan = 4
+        settings.speed = 0.5
+        settings.speedVariation = 0.5
+        settings.angleRange = .degrees(90)
+        settings.acceleration = [0, 1]
+        settings.angularSpeedVariation = [4, 4, 4]
+        settings.colors = .random(.white, .red, .green, .blue, .pink, .orange, .cyan)
+        settings.size = 0.5
+        settings.sizeVariation = 0.5
+    }
 }

--- a/Sources/Vortex/Presets/Fire.swift
+++ b/Sources/Vortex/Presets/Fire.swift
@@ -10,18 +10,32 @@ import SwiftUI
 extension VortexSystem {
     /// A built-in fire effect. Relies on a "circle" tag being present, which should be set to use 
     /// `.blendMode(.plusLighter)`.
-    public static let fire: VortexSystem = {
-        VortexSystem(
-            tags: ["circle"],
-            shape: .box(width: 0.1, height: 0),
-            birthRate: 300,
-            speed: 0.2,
-            speedVariation: 0.2,
-            angleRange: .degrees(10),
-            attractionStrength: 2,
-            colors: .ramp(.brown, .brown, .brown, .brown.opacity(0)),
-            sizeVariation: 0.5,
-            sizeMultiplierAtDeath: 0.1
-        )
-    }()
+    public static let fire = VortexSystem(settings: .fire)
+}
+
+
+extension VortexSystem.Settings { 
+    /// A built-in fire effect. Relies on a "circle" tag being present, which should be set to use 
+    /// `.blendMode(.plusLighter)`.
+    public static let fire = VortexSystem.Settings { settings in
+        settings.tags = ["circle"]
+        settings.shape = .box(width: 0.1, height: 0)
+        settings.birthRate = 300
+        settings.speed = 0.2
+        settings.speedVariation = 0.2
+        settings.angleRange = .degrees(10)
+        settings.attractionStrength = 2
+        settings.colors = .ramp(.brown, .brown, .brown, .brown.opacity(0))
+        settings.sizeVariation = 0.5
+        settings.sizeMultiplierAtDeath = 0.1
+    }
+}
+
+#Preview {
+    let floorOnFire = VortexSystem.Settings(from: .fire ) { settings in
+        settings.position = [ 0.5, 1.02]
+        settings.shape = .box(width: 1.0, height: 0)
+        settings.birthRate = 600 
+    } 
+    VortexView(settings: floorOnFire) 
 }

--- a/Sources/Vortex/Presets/Fireflies.swift
+++ b/Sources/Vortex/Presets/Fireflies.swift
@@ -10,20 +10,23 @@ import SwiftUI
 extension VortexSystem {
     /// A built-in firefly effect. Relies on a "circle" tag being present, which should be set to use
     /// `.blendMode(.plusLighter)`.
-    public static let fireflies: VortexSystem = {
-        VortexSystem(
-            tags: ["circle"],
-            shape: .ellipse(radius: 0.5),
-            birthRate: 200,
-            lifespan: 2,
-            speed: 0,
-            speedVariation: 0.25,
-            angleRange: .degrees(360),
-            colors: .ramp(.yellow, .yellow, .yellow.opacity(0)),
-            size: 0.01,
-            sizeMultiplierAtDeath: 100
-        )
-    }()
+    public static let fireflies = VortexSystem(settings: .fireflies)
+}
+
+extension VortexSystem.Settings {  
+    /// A built-in firefly effect. Uses the built-in 'circle' image.
+    public static let fireflies = VortexSystem.Settings() { settings in 
+        settings.tags = ["circle"]
+        settings.shape = .ellipse(radius: 0.5)
+        settings.birthRate = 200
+        settings.lifespan = 2
+        settings.speed = 0
+        settings.speedVariation = 0.25
+        settings.angleRange = .degrees(360)
+        settings.colors = .ramp(.yellow, .yellow, .yellow.opacity(0))
+        settings.size = 0.01
+        settings.sizeMultiplierAtDeath = 100
+    }
 }
 
 /// A Fireflies preview, using the `.fireflies` preset
@@ -48,7 +51,7 @@ extension VortexSystem {
                     .padding(.bottom, 20)
             }
             
-            VortexView(.fireflies) 
+            VortexView(settings: .fireflies) 
                 .onModifierKeysChanged(mask: .option) { _, new in
                     // set the view state based on whether the 
                     // `new` EventModifiers value contains a value (that would be the option key)
@@ -59,12 +62,12 @@ extension VortexSystem {
                         .onChanged { value in
                             proxy.attractTo(value.location)
                             proxy.particleSystem?
-                                .attractionStrength = pressingOptionKey ? 2.5 : -2
+                                .vortexSettings.attractionStrength = pressingOptionKey ? 2.5 : -2
                             isDragging = true
                         }
                         .onEnded { _ in
                             proxy.particleSystem?
-                                .attractionStrength = 0
+                                .vortexSettings.attractionStrength = 0
                             isDragging = false
                         }
                 )

--- a/Sources/Vortex/Presets/Fireworks.swift
+++ b/Sources/Vortex/Presets/Fireworks.swift
@@ -9,56 +9,66 @@ import SwiftUI
 
 extension VortexSystem {
     /// A built-in fireworks effect, using secondary systems that create sparkles and explosions.
-    /// Relies on a "circle" tag being present, which should be set to use
+    /// Relies on the built in circle symbol, or a symbol with the "circle" tag being present, which should be set to use
     /// `.blendMode(.plusLighter)`.
-    public static let fireworks: VortexSystem = {
-        let sparkles = VortexSystem(
-            tags: ["circle"],
-            spawnOccasion: .onUpdate,
-            emissionLimit: 1,
-            lifespan: 0.5,
-            speed: 0.05,
-            angleRange: .degrees(90),
-            size: 0.05
-        )
+    public static let fireworks = VortexSystem(settings: .fireworks)
+}
 
-        let explosion = VortexSystem(
-            tags: ["circle"],
-            spawnOccasion: .onDeath,
-            position: [0.5, 1],
-            birthRate: 100_000,
-            emissionLimit: 500,
-            speed: 0.5,
-            speedVariation: 1,
-            angleRange: .degrees(360),
-            acceleration: [0, 1.5],
-            dampingFactor: 4,
-            colors: .randomRamp(
+extension VortexSystem.Settings {
+    /// A built-in fireworks effect, using secondary systems that create sparkles and explosions.
+    /// Relies on a symbol view tagged with "circle" being available to the VortexView.  (one such image is built-in)
+    public static let fireworks = VortexSystem.Settings { settings in
+        
+        var sparkles = VortexSystem.Settings { sparkle in
+            sparkle.tags = ["sparkle"]
+            sparkle.spawnOccasion = .onUpdate
+            sparkle.emissionLimit = 1
+            sparkle.lifespan = 0.5
+            sparkle.speed = 0.05
+            sparkle.angleRange = .degrees(180)
+            sparkle.size = 0.05
+        }
+        
+        var explosions = VortexSystem.Settings { explosion in 
+            explosion.tags = ["circle"]
+            explosion.spawnOccasion = .onDeath
+            explosion.position = [0.5, 0.5]
+            explosion.birthRate = 100_000
+            explosion.emissionLimit = 500
+            explosion.speed = 0.5
+            explosion.speedVariation = 1
+            explosion.angleRange = .degrees(360)
+            explosion.acceleration = [0, 1.5]
+            explosion.dampingFactor = 4
+            explosion.colors = .randomRamp(
                 [.white, .pink, .pink],
                 [.white, .blue, .blue],
                 [.white, .green, .green],
                 [.white, .orange, .orange],
                 [.white, .cyan, .cyan]
-            ),
-            size: 0.15,
-            sizeVariation: 0.1,
-            sizeMultiplierAtDeath: 0
-        )
+            )
+            explosion.size = 0.15
+            explosion.sizeVariation = 0.1
+            explosion.sizeMultiplierAtDeath = 0
+        }
 
-        let mainSystem = VortexSystem(
-            tags: ["circle"],
-            secondarySystems: [sparkles, explosion],
-            position: [0.5, 1],
-            birthRate: 2,
-            emissionLimit: 1000,
-            speed: 1.5,
-            speedVariation: 0.75,
-            angleRange: .degrees(60),
-            dampingFactor: 2,
-            size: 0.15,
-            stretchFactor: 4
-        )
+        
+        settings.tags = ["circle"]
+        settings.secondarySettings = [sparkles, explosions]
+        settings.position = [0.5, 1]
+        settings.birthRate = 2
+        settings.emissionLimit = 1000
+        settings.speed = 1.5
+        settings.speedVariation = 0.75
+        settings.angleRange = .degrees(60)
+        settings.dampingFactor = 2
+        settings.size = 0.15
+        settings.stretchFactor = 4
+    }
+}
 
-        return mainSystem
-    }()
+#Preview("Fireworks") {
+    VortexView(settings: .fireworks)
+        .navigationSubtitle("Demonstrates multi-stage effects")
+        .ignoresSafeArea(edges: .top)
 }

--- a/Sources/Vortex/Settings/Settings.swift
+++ b/Sources/Vortex/Settings/Settings.swift
@@ -1,0 +1,314 @@
+//
+// Settings.swift
+// Vortex
+// https://www.github.com/twostraws/Vortex
+// See LICENSE for license information.
+//
+
+import SwiftUI
+
+extension VortexSystem {
+
+    /// Contains the variables used to configure a Vortex System for use with a `VortexView`.
+    /// Properties:-
+    ///   - **tags**: The list of possible tags to use for this particle system. This might be the
+    ///     full set of tags passed into a `VortexView`, but might also be a subset if
+    ///     secondary systems use other tags.
+    ///   - secondarySettings: The list of secondary settings for reac secondary system that can be created.
+    ///     Defaults to an empty array.
+    ///   - spawnOccasion: When this particle system should be spawned.
+    ///     This is useful only for secondary systems. Defaults to `.onBirth`.
+    ///   - position: The current position of this particle system, in unit space.
+    ///     Defaults to [0.5, 0.5].
+    ///   - shape: The shape of this particle system, which controls where particles
+    ///     are created relative to the system's position. Defaults to `.point`.
+    ///   - birthRate: How many particles are created every second. You can use
+    ///     values below 1 here, e.g a birth rate of 0.2 means one particle being created
+    ///     every 5 seconds. Defaults to 100.
+    ///   - emissionLimit: The total number of particles this system should create.
+    ///     A value of `nil` means no limit. Defaults to `nil`.
+    ///   - emissionDuration: How long this system should emit particles for before
+    ///     pausing, measured in seconds. Defaults to 1.
+    ///   - idleDuration: How long this system should wait between particle
+    ///     emissions, measured in seconds. Defaults to 0.
+    ///   - burstCount: How many particles should be emitted when a burst is requested.
+    ///     Defaults to 100.
+    ///   - burstCountVariation: How much variation should be allowed in bursts.
+    ///     Defaults to 0.
+    ///   - lifespan: How long particles should live for, measured in seconds. Defaults
+    ///     to 1.
+    ///   - lifespanVariation: How much variation to allow in particle lifespan.
+    ///     Defaults to 0.
+    ///   - speed: The base rate of movement for particles. A speed of 1 means the
+    ///     system will move from one side to the other in one second. Defaults to 1.
+    ///   - speedVariation: How much variation to allow in particle speed. Defaults
+    ///     to 0.
+    ///   - angle: The base direction to launch new particles, where 0 is directly up. Defaults
+    ///     to 0.
+    ///   - angleRange: How much variation to use in particle launch direction. Defaults to 0.
+    ///   - acceleration: How much acceleration to apply for particle movement.
+    ///     Defaults to 0, meaning that no acceleration is applied.
+    ///   - attractionCenter: A specific point particles should move towards or away
+    ///     from, based on `attractionStrength`. A `nil` value here means
+    ///     no attraction. Defaults to `nil`.
+    ///   - attractionStrength: How fast to move towards `attractionCenter`,
+    ///     when it is not `nil`. Defaults to 0
+    ///   - dampingFactor: How fast movement speed should be slowed down. Defaults to 0.
+    ///   - angularSpeed: How fast particles should spin. Defaults to `[0, 0, 0]`.
+    ///   - angularSpeedVariation: How much variation to allow in particle spin speed.
+    ///     Defaults to `[0, 0, 0]`.
+    ///   - colors: What colors to use for particles made by this system. If `randomRamp`
+    ///     is used then this system picks one possible color ramp to use. Defaults to
+    ///     `.single(.white)`.
+    ///   - size: How large particles should be drawn, where a value of 1 means 100%
+    ///     the image size. Defaults to 1.
+    ///   - sizeVariation: How much variation to use for particle size. Defaults to 0
+    ///   - sizeMultiplierAtDeath: How how much bigger or smaller this particle should
+    ///     be by the time it is removed. This is used as a multiplier based on the particle's initial
+    ///     size, so if it starts at size 0.5 and has a `sizeMultiplierAtDeath` of 0.5, the
+    ///     particle will finish at size 0.25. Defaults to 1.
+    ///   - stretchFactor: How much to stretch this particle's image based on its movement
+    ///     speed. Larger values cause more stretching. Defaults to 1 (no stretch).
+    ///
+    public struct Settings: Equatable, Hashable, Identifiable, Codable {
+        /// Unique id. Set as variable to allow decodable conformance without compiler quibbles.
+        public var id: UUID = UUID()
+
+        /// Equatable conformance
+        public static func == (
+            lhs: VortexSystem.Settings, rhs: VortexSystem.Settings
+        ) -> Bool {
+            lhs.id == rhs.id
+        }
+        /// Hashable conformance
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(id)
+        }
+
+        // These properties control system-wide behavior.
+        /// The current position of this particle system, in unit space.
+        /// Defaults to the centre.
+        public var position: SIMD2<Double> = [0.5, 0.5]
+
+        /// The list of possible tags to use for this particle system. This might be the full set of
+        /// tags passed into a `VortexView`, but might also be a subset if secondary systems
+        /// use other tags.
+        /// Defaults to "circle"
+        public var tags: [String] = ["circle"]
+
+        /// Whether this particle system should actively be emitting right now.
+        /// Defaults to true
+        public var isEmitting = true
+
+        /// The list of secondary settings associated with this setting. Empty by default.
+        public var secondarySettings = [Settings]()
+
+        /// When this particle system should be spawned. This is useful only for secondary systems.
+        /// Defaults to `.onBirth`
+        public var spawnOccasion: SpawnOccasion = .onBirth
+
+        // These properties control how particles are created.
+        /// The shape of this particle system, which controls where particles are created relative to
+        /// the system's position.
+        /// Defaults to `.point`
+        public var shape: Shape = .point
+
+        /// How many particles are created every second. You can use values below 1 here, e.g
+        /// a birth rate of 0.2 means one particle being created every 5 seconds.
+        /// Defaults to 100
+        public var birthRate: Double = 100
+
+        /// The total number of particles this system should create.
+        /// The default value of `nil` means no limit.
+        public var emissionLimit: Int? = nil
+
+        /// How long this system should emit particles for before pausing, measured in seconds.
+        /// Defaults to 1
+        public var emissionDuration: TimeInterval = 1
+
+        /// How long this system should wait between particle emissions, measured in seconds.
+        /// Defaults to 0
+        public var idleDuration: TimeInterval = 0
+
+        /// How many particles should be emitted when a burst is requested.
+        /// Defaults to 100
+        public var burstCount: Int = 100
+
+        /// How much variation should be allowed in bursts.
+        /// Defaults to 0
+        public var burstCountVariation: Int = .zero
+
+        /// How long particles should live for, measured in seconds.
+        /// Defaults to 1
+        public var lifespan: TimeInterval = 1
+
+        /// How much variation to allow in particle lifespan.
+        /// Defaults to 0
+        public var lifespanVariation: TimeInterval = 0
+
+        // These properties control how particles move.
+        /// The base rate of movement for particles.
+        /// The default speed of 1 means the system will move
+        /// from one side to the other in one second.
+        public var speed: Double = 1
+
+        /// How much variation to allow in particle speed.
+        /// Defaults to 0
+        public var speedVariation: Double = .zero
+
+        /// The base direction to launch new particles, where 0 is directly up.
+        /// Defaults to 0
+        public var angle: Angle = .zero
+
+        /// How much variation to use in particle launch direction.
+        /// Defaults to 0
+        public var angleRange: Angle = .zero
+
+        /// How much acceleration to apply for particle movement. Set to 0 by default, meaning
+        /// that no acceleration is applied.
+        public var acceleration: SIMD2<Double> = [0, 0]
+
+        /// A specific point particles should move towards or away from, based
+        /// on `attractionStrength`. A `nil` value here means no attraction.
+        public var attractionCenter: SIMD2<Double>? = nil
+
+        /// How fast to move towards `attractionCenter`, when it is not `nil`.
+        /// Defaults to 0
+        public var attractionStrength: Double = .zero
+
+        /// How fast movement speed should be slowed down.
+        /// Defaults to 0
+        public var dampingFactor: Double = .zero
+
+        /// How fast particles should spin.
+        /// Defaults to zero
+        public var angularSpeed: SIMD3<Double> = [0, 0, 0]
+
+        /// How much variation to allow in particle spin speed.
+        /// Defaults to zero
+        public var angularSpeedVariation: SIMD3<Double> = [0, 0, 0]
+
+        // These properties determine how particles are drawn.
+
+        /// How large particles should be drawn, where a value of 1, the default, means 100% of the image size.
+        public var size: Double = 1
+
+        /// How much variation to use for particle size.
+        /// Defaults to zero
+        public var sizeVariation: Double = .zero
+
+        /// How how much bigger or smaller this particle should be by the time it is removed.
+        /// This is used as a multiplier based on the particle's initial size, so if it starts at size
+        /// 0.5 and has a `sizeMultiplierAtDeath` of 0.5, the particle will finish
+        /// at size 0.25.
+        /// Defaults to zero
+        public var sizeMultiplierAtDeath: Double = .zero
+
+        /// How much to stretch this particle's image based on its movement speed. Larger values
+        /// cause more stretching.
+        /// Defaults to zero
+        public var stretchFactor: Double = .zero
+
+        /// What colors to use for particles made by this system. If `randomRamp` is used
+        /// then the VortexSystem initialiser will pick one possible color ramp to use.
+        /// A single, white, color is used by default.
+        public var colors: VortexSystem.ColorMode = .single(.white) 
+
+        /// VortexSettings initialisation.
+        /// - Parameters: None. Uses sensible default values on initialisation, with no parameters required.
+        public init() {}
+
+        /// Convenient init for VortexSettings initialisation.  Allows initialisation based on an existing settings struct, copies it into a new struct and modifiiesf it via a supplied closure
+        /// - Parameters:
+        ///  - from: `VortexSettings`
+        ///  The base settings struct to be used as a base. Defaullt settings will be used if not supplied.
+        ///  - : @escaping (inout VortexSettings)->Void
+        ///  An anonymous closure which will modify the settings supplied in the first parameter
+        /// e.g.
+        /// ```swift
+        /// let newFireSettings = VortexSystem.Settings(from: .fire ) { settings in
+        ///         settings.position = [ 0.5, 1.03]
+        ///         settings.shape = .box(width: 1.0, height: 0)
+        ///         settings.birthRate = 600
+        ///     }
+        /// ```
+        public init(
+            from base: VortexSystem.Settings = VortexSystem.Settings(),
+            _ modifiedBy: @escaping (_: inout VortexSystem.Settings) -> Void
+        ) {
+            // Take a copy of the base struct, and generate new id
+            var newSettings = base
+            newSettings.id = UUID()
+            // Amend newSettings by calling the supplied closure
+            modifiedBy(&newSettings)
+            self = newSettings
+        }
+
+        /// Formerly used to make deep copies of the VortexSystem class so that secondary systems functioned correctly.
+        /// No longer needed, but created here for backward compatibility if the VortexSystem initialiser taking a Settings
+        /// struct is updated to be identical to the old init that took a VortexSystem initialiser.
+        public func makeUniqueCopy() -> VortexSystem.Settings {
+            return self
+        }
+
+        /// Backward compatibility again:
+        public init(
+            tags: [String],
+            spawnOccasion: SpawnOccasion = .onBirth,
+            position: SIMD2<Double> = [0.5, 0.5],
+            shape: Shape = .point,
+            birthRate: Double = 100,
+            emissionLimit: Int? = nil,
+            emissionDuration: Double = 1,
+            idleDuration: Double = 0,
+            burstCount: Int = 100,
+            burstCountVariation: Int = 0,
+            lifespan: TimeInterval = 1,
+            lifespanVariation: TimeInterval = 0,
+            speed: Double = 1,
+            speedVariation: Double = 0,
+            angle: Angle = .zero,
+            angleRange: Angle = .zero,
+            acceleration: SIMD2<Double> = [0, 0],
+            attractionCenter: SIMD2<Double>? = nil,
+            attractionStrength: Double = 0,
+            dampingFactor: Double = 0,
+            angularSpeed: SIMD3<Double> = [0, 0, 0],
+            angularSpeedVariation: SIMD3<Double> = [0, 0, 0],
+            colors: ColorMode = .single(.white),
+            size: Double = 1,
+            sizeVariation: Double = 0,
+            sizeMultiplierAtDeath: Double = 1,
+            stretchFactor: Double = 1
+        ) {
+            id = UUID()
+            self.tags = tags
+            self.spawnOccasion = spawnOccasion
+            self.position = position
+            self.shape = shape
+            self.birthRate = birthRate
+            self.emissionLimit = emissionLimit
+            self.emissionDuration = emissionDuration
+            self.idleDuration = idleDuration
+            self.burstCount = burstCount
+            self.burstCountVariation = burstCountVariation
+            self.lifespan = lifespan
+            self.lifespanVariation = lifespanVariation
+            self.speed = speed
+            self.speedVariation = speedVariation
+            self.angle = angle
+            self.acceleration = acceleration
+            self.angleRange = angleRange
+            self.attractionCenter = attractionCenter
+            self.attractionStrength = attractionStrength
+            self.dampingFactor = dampingFactor
+            self.angularSpeed = angularSpeed
+            self.angularSpeedVariation = angularSpeedVariation
+            self.colors = colors
+            self.size = size
+            self.sizeVariation = sizeVariation
+            self.sizeMultiplierAtDeath = sizeMultiplierAtDeath
+            self.stretchFactor = stretchFactor
+        }
+    }
+}

--- a/Sources/Vortex/System/VortexSystem-Behavior.swift
+++ b/Sources/Vortex/System/VortexSystem-Behavior.swift
@@ -24,11 +24,11 @@ extension VortexSystem {
         let delta = currentTimeInterval - lastUpdate
         lastUpdate = currentTimeInterval
 
-        if isEmitting && lastUpdate - lastIdleTime > emissionDuration {
-            isEmitting = false
+        if vortexSettings.isEmitting && lastUpdate - lastIdleTime > vortexSettings.emissionDuration {
+            vortexSettings.isEmitting = false
             lastIdleTime = lastUpdate
-        } else if isEmitting == false && lastUpdate - lastIdleTime > idleDuration {
-            isEmitting = true
+        } else if vortexSettings.isEmitting == false && lastUpdate - lastIdleTime > vortexSettings.idleDuration {
+            vortexSettings.isEmitting = true
             lastIdleTime = lastUpdate
         }
 
@@ -38,9 +38,9 @@ extension VortexSystem {
 
         // Push attraction strength down to a small number, otherwise
         // it's much too strong.
-        let adjustedAttractionStrength = attractionStrength / 1000
+        let adjustedAttractionStrength = vortexSettings.attractionStrength / 1000
 
-        if let attractionCenter {
+        if let attractionCenter = vortexSettings.attractionCenter {
             attractionUnitPoint = [attractionCenter.x / drawSize.width, attractionCenter.y / drawSize.height]
         }
 
@@ -69,18 +69,18 @@ extension VortexSystem {
             particle.position.x += particle.speed.x * delta * drawDivisor
             particle.position.y += particle.speed.y * delta
 
-            if dampingFactor != 1 {
-                let dampingAmount = dampingFactor * delta / lifespan
+            if vortexSettings.dampingFactor != 1 {
+                let dampingAmount = vortexSettings.dampingFactor * delta / vortexSettings.lifespan
                 particle.speed -= particle.speed * dampingAmount
             }
 
-            particle.speed += acceleration * delta
+            particle.speed += vortexSettings.acceleration * delta
             particle.angle += particle.angularSpeed * delta
 
             particle.currentColor = particle.colors.lerp(by: lifeProgress)
 
             particle.currentSize = particle.initialSize.lerp(
-                to: particle.initialSize * sizeMultiplierAtDeath,
+                to: particle.initialSize * vortexSettings.sizeMultiplierAtDeath,
                 amount: lifeProgress
             )
 
@@ -95,7 +95,7 @@ extension VortexSystem {
     }
 
     private func createParticles(delta: Double) {
-        outstandingParticles += birthRate * delta
+        outstandingParticles += vortexSettings.birthRate * delta
 
         if outstandingParticles >= 1 {
             let particlesToCreate = Int(outstandingParticles)
@@ -122,19 +122,19 @@ extension VortexSystem {
     /// - Parameter force: When true, this will create a particle even if
     /// this system has already reached its emission limit.
     func createParticle(force: Bool = false) {
-        guard isEmitting else { return }
+        guard vortexSettings.isEmitting else { return }
 
-        if let emissionLimit {
+        if let emissionLimit = vortexSettings.emissionLimit {
             if emissionCount >= emissionLimit && force == false {
                 return
             }
         }
 
         // We subtract half of pi here to ensure that angle 0 is directly up.
-        let launchAngle = angle.radians + angleRange.radians.randomSpread() - .pi / 2
-        let launchSpeed = speed + speedVariation.randomSpread()
-        let lifespan = lifespan + lifespanVariation.randomSpread()
-        let size = size + sizeVariation.randomSpread()
+        let launchAngle = vortexSettings.angle.radians + vortexSettings.angleRange.radians.randomSpread() - .pi / 2
+        let launchSpeed = vortexSettings.speed + vortexSettings.speedVariation.randomSpread()
+        let lifespan = vortexSettings.lifespan + vortexSettings.lifespanVariation.randomSpread()
+        let size = vortexSettings.size + vortexSettings.sizeVariation.randomSpread()
         let particlePosition = getNewParticlePosition()
 
         let speed = SIMD2(
@@ -142,11 +142,11 @@ extension VortexSystem {
             sin(launchAngle) * launchSpeed
         )
 
-        let spinSpeed = angularSpeed + angularSpeedVariation.randomSpread()
+        let spinSpeed = vortexSettings.angularSpeed + vortexSettings.angularSpeedVariation.randomSpread()
         let colorRamp = getNewParticleColorRamp()
 
         let newParticle = Particle(
-            tag: tags.randomElement() ?? "",
+            tag: vortexSettings.tags.randomElement() ?? "",
             position: particlePosition,
             speed: speed,
             birthTime: lastUpdate,
@@ -163,7 +163,7 @@ extension VortexSystem {
 
     /// Force a bunch of particles to be created immediately.
     func burst() {
-        let particlesToCreate = burstCount + burstCountVariation.randomSpread()
+        let particlesToCreate = vortexSettings.burstCount + vortexSettings.burstCountVariation.randomSpread()
 
         for _ in 0..<particlesToCreate {
             createParticle(force: true)
@@ -172,24 +172,32 @@ extension VortexSystem {
 
     /// Finds and creates any appropriate secondary systems for this particle.
     func spawn(from particle: Particle, event: SpawnOccasion) {
+        /// Check secondary settings for a new system that should be spawned
+        let matchedSettings = vortexSettings.secondarySettings.filter { $0.spawnOccasion == event }
+        for settings in matchedSettings {
+            let newSystem = VortexSystem(settings: settings)
+            newSystem.vortexSettings.position = particle.position
+            activeSecondarySystems.insert(newSystem)
+        }
+        /// If the deprecated init is still used, then the secondarySystem may be populated
         let secondarySystems = secondarySystems.filter { $0.spawnOccasion == event }
-
         for secondarySystem in secondarySystems {
+            // The call to makeUniqueCopy() is needed below, but is unnecessary when using secondarySettings.
             let newSystem = secondarySystem.makeUniqueCopy()
-            newSystem.position = particle.position
+            newSystem.vortexSettings.position = particle.position
             activeSecondarySystems.insert(newSystem)
         }
     }
 
     func getNewParticlePosition() -> SIMD2<Double> {
-        switch shape {
+        switch vortexSettings.shape {
         case .point:
-            return position
+                return vortexSettings.position
 
         case .box(let width, let height):
             return [
-                position.x + width.randomSpread(),
-                position.y + height.randomSpread()
+                vortexSettings.position.x + width.randomSpread(),
+                vortexSettings.position.y + height.randomSpread()
             ]
 
         case .ellipse(let radius):
@@ -197,22 +205,22 @@ extension VortexSystem {
             let placement = Double.random(in: 0...radius / 2)
 
             return [
-                placement * cos(angle) + position.x,
-                placement * sin(angle) + position.y
+                placement * cos(angle) + vortexSettings.position.x,
+                placement * sin(angle) + vortexSettings.position.y
             ]
 
         case .ring(let radius):
             let angle = Double.random(in: 0...(2 * .pi))
 
             return [
-                radius / 2 * cos(angle) + position.x,
-                radius / 2 * sin(angle) + position.y
+                radius / 2 * cos(angle) + vortexSettings.position.x,
+                radius / 2 * sin(angle) + vortexSettings.position.y
             ]
         }
     }
 
     func getNewParticleColorRamp() -> [Color] {
-        switch colors {
+        switch vortexSettings.colors {
         case .single(let color):
             return [color]
 

--- a/Sources/Vortex/System/VortexSystem.swift
+++ b/Sources/Vortex/System/VortexSystem.swift
@@ -8,17 +8,12 @@
 import SwiftUI
 
 /// The main particle system generator class that powers Vortex.
-public class VortexSystem: Codable, Identifiable, Equatable, Hashable {
-    /// The subset of properties we need to load and save to handle Codable correctly.
-    enum CodingKeys: CodingKey {
-        case tags, secondarySystems, spawnOccasion, position, shape, birthRate, emissionLimit, emissionDuration
-        case idleDuration, burstCount, burstCountVariation, lifespan, lifespanVariation, speed, speedVariation, angle
-        case angleRange, acceleration, attractionCenter, attractionStrength, dampingFactor, angularSpeed
-        case angularSpeedVariation, colors, size, sizeVariation, sizeMultiplierAtDeath, stretchFactor
-    }
+@dynamicMemberLookup
+public class VortexSystem: Identifiable, Equatable, Hashable {
 
     /// A public identifier  to satisfy Identifiable
     public let id = UUID()
+    
     /// Equatable conformance
     public static func == (lhs: VortexSystem, rhs: VortexSystem) -> Bool {
         lhs.id == rhs.id
@@ -27,7 +22,10 @@ public class VortexSystem: Codable, Identifiable, Equatable, Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     } 
-
+    /// Virtual 'add' of the Settings properties to the vortex system
+    subscript<T>(dynamicMember keyPath: KeyPath<VortexSystem.Settings, T>) -> T {
+        vortexSettings[keyPath: keyPath]
+    }
 
     // These properties are used for managing a live system, rather
     // than for configuration purposes.
@@ -60,122 +58,36 @@ public class VortexSystem: Codable, Identifiable, Equatable, Hashable {
     var lastDrawSize = CGSize.zero
 
     // These properties control system-wide behavior.
-    /// The current position of this particle system, in unit space.
-    public var position: SIMD2<Double>
+    
+    /// The configuration settings for a VortexSystem
+    var vortexSettings: VortexSystem.Settings
 
-    /// The list of possible tags to use for this particle system. This might be the full set of
-    /// tags passed into a `VortexView`, but might also be a subset if secondary systems
-    /// use other tags.
-    public var tags = [String]()
-
-    /// Whether this particle system should actively be emitting right now.
-    public var isEmitting = true
-
-    /// The list of secondary systems that can be created by this system.
-    public var secondarySystems = [VortexSystem]()
-
-    /// When this particle system should be spawned. This is useful only for secondary systems.
-    public var spawnOccasion: SpawnOccasion
-
-    // These properties control how particles are created.
-    /// The shape of this particle system, which controls where particles are created relative to
-    /// the system's position.
-    public var shape: Shape
-
-    /// How many particles are created every second. You can use values below 1 here, e.g
-    /// a birth rate of 0.2 means one particle being created every 5 seconds.
-    public var birthRate: Double
-
-    /// The total number of particles this system should create. A value of `nil` means no limit.
-    public var emissionLimit: Int?
-
-    /// How long this system should emit particles for before pausing, measured in seconds.
-    public var emissionDuration: TimeInterval
-
-    /// How long this system should wait between particle emissions, measured in seconds.
-    public var idleDuration: TimeInterval
-
-    /// How many particles should be emitted when a burst is requested.
-    public var burstCount: Int
-
-    /// How much variation should be allowed in bursts.
-    public var burstCountVariation: Int
-
-    /// How long particles should live for, measured in seconds.
-    public var lifespan: TimeInterval
-
-    /// How much variation to allow in particle lifespan.
-    public var lifespanVariation: TimeInterval
-
-    // These properties control how particles move.
-    /// The base rate of movement for particles. A speed of 1 means the system will move
-    /// from one side to the other in one second.
-    public var speed: Double
-
-    /// How much variation to allow in particle speed.
-    public var speedVariation: Double
-
-    /// The base direction to launch new particles, where 0 is directly up.
-    public var angle: Angle
-
-    /// How much variation to use in particle launch direction.
-    public var angleRange: Angle
-
-    /// How much acceleration to apply for particle movement. Set to 0 by default, meaning
-    /// that no acceleration is applied.
-    public var acceleration: SIMD2<Double>
-
-    /// A specific point particles should move towards or away from, based
-    /// on `attractionStrength`. A `nil` value here means no attraction.
-    public var attractionCenter: SIMD2<Double>?
-
-    /// How fast to move towards `attractionCenter`, when it is not `nil`.
-    public var attractionStrength: Double
-
-    /// How fast movement speed should be slowed down.
-    public var dampingFactor: Double
-
-    /// How fast particles should spin.
-    public var angularSpeed: SIMD3<Double>
-
-    /// How much variation to allow in particle spin speed.
-    public var angularSpeedVariation: SIMD3<Double>
-
-    // These properties determine how particles are drawn.
-    /// What colors to use for particles made by this system. If `randomRamp` is used
-    /// then this system picks one possible color ramp to use.
-    public var colors: ColorMode {
-        didSet {
-            if case let .randomRamp(allColors) = colors {
-                self.selectedColorRamp = Int.random(in: 0..<allColors.count)
-            }
+    /// Backwards compatibility only - use is deprecated
+    /// The secondary systems to be used in the particle system
+    var secondarySystems: [VortexSystem] = []
+    
+    /// Initialise a particle system with a VortexSettings struct
+    /// - Parameter settings: VortexSettings    
+    /// The settings to be used for this particle system.   
+    public init( settings: VortexSystem.Settings ) {
+        self.vortexSettings = settings
+        // Ensure that randomisation is set correctly if settings are copied.
+        // (This is important when creating a secondary system)
+        if case let .randomRamp(allColors) = vortexSettings.colors {
+            selectedColorRamp = Int.random(in: 0..<allColors.count)
         }
     }
 
-    /// How large particles should be drawn, where a value of 1 means 100% the image size.
-    public var size: Double
-
-    /// How much variation to use for particle size.
-    public var sizeVariation: Double
-
-    /// How how much bigger or smaller this particle should be by the time it is removed.
-    /// This is used as a multiplier based on the particle's initial size, so if it starts at size
-    /// 0.5 and has a `sizeMultiplierAtDeath` of 0.5, the particle will finish
-    /// at size 0.25.
-    public var sizeMultiplierAtDeath: Double
-
-    /// How much to stretch this particle's image based on its movement speed. Larger values
-    /// cause more stretching.
-    public var stretchFactor: Double
-
-    /// Creates a new particle system. Most values here have sensible defaults, but you do need
+    /// Creates a new particle system. - Deprecated.
+    /// Most values here have sensible defaults, but you do need
     /// to provide a list of tags matching whatever you're using with `VortexView`.
     /// - Parameters:
     ///   - tags: The list of possible tags to use for this particle system. This might be the
     ///     full set of tags passed into a `VortexView`, but might also be a subset if
     ///     secondary systems use other tags.
+    //     **Secondary systems through this initialiser cannot be supported and will generate an error 
     ///   - secondarySystems: The list of secondary systems that can be created
-    ///     by this system. Defaults to an empty array.
+    ///     by this system. Always set to an empty array.
     ///   - spawnOccasion: When this particle system should be spawned.
     ///     This is useful only for secondary systems. Defaults to `.onBirth`.
     ///   - position: The current position of this particle system, in unit space.
@@ -229,6 +141,8 @@ public class VortexSystem: Codable, Identifiable, Equatable, Hashable {
     ///     particle will finish at size 0.25. Defaults to 1.
     ///   - stretchFactor: How much to stretch this particle's image based on its movement
     ///     speed. Larger values cause more stretching. Defaults to 1 (no stretch).
+    /// For backward compatibility only
+    @available(*, deprecated, message: "Initialise a VortexSystem with the `settings:` parameter to remove this warning. ")
     public init(
         tags: [String],
         secondarySystems: [VortexSystem] = [],
@@ -259,47 +173,9 @@ public class VortexSystem: Codable, Identifiable, Equatable, Hashable {
         sizeMultiplierAtDeath: Double = 1,
         stretchFactor: Double = 1
     ) {
-        self.tags = tags
         self.secondarySystems = secondarySystems
-        self.spawnOccasion = spawnOccasion
-        self.position = position
-        self.shape = shape
-        self.birthRate = birthRate
-        self.emissionLimit = emissionLimit
-        self.emissionDuration = emissionDuration
-        self.idleDuration = idleDuration
-        self.burstCount = burstCount
-        self.burstCountVariation = burstCountVariation
-        self.lifespan = lifespan
-        self.lifespanVariation = lifespanVariation
-        self.speed = speed
-        self.speedVariation = speedVariation
-        self.angle = angle
-        self.acceleration = acceleration
-        self.angleRange = angleRange
-        self.attractionCenter = attractionCenter
-        self.attractionStrength = attractionStrength
-        self.dampingFactor = dampingFactor
-        self.angularSpeed = angularSpeed
-        self.angularSpeedVariation = angularSpeedVariation
-        self.colors = colors
-        self.size = size
-        self.sizeVariation = sizeVariation
-        self.sizeMultiplierAtDeath = sizeMultiplierAtDeath
-        self.stretchFactor = stretchFactor
-
-        if case let .randomRamp(allColors) = colors {
-            selectedColorRamp = Int.random(in: 0..<allColors.count)
-        }
-    }
-
-    /// Because particle systems are classes rather than structs, we need to make deep
-    /// copies by hand. This is important when creating a secondary system. This method
-    /// copies all values across.
-    public func makeUniqueCopy() -> VortexSystem {
-        VortexSystem(
+        self.vortexSettings = Settings(
             tags: tags,
-            secondarySystems: secondarySystems,
             spawnOccasion: spawnOccasion,
             position: position,
             shape: shape,
@@ -320,12 +196,53 @@ public class VortexSystem: Codable, Identifiable, Equatable, Hashable {
             attractionStrength: attractionStrength,
             dampingFactor: dampingFactor,
             angularSpeed: angularSpeed,
-            angularSpeedVariation: angularSpeedVariation,
+            angularSpeedVariation: angularSpeed,
             colors: colors,
             size: size,
             sizeVariation: sizeVariation,
             sizeMultiplierAtDeath: sizeMultiplierAtDeath,
             stretchFactor: stretchFactor
+        )
+
+        if case .randomRamp(let allColors) = colors {
+            selectedColorRamp = Int.random(in: 0..<allColors.count)
+        }
+    }
+
+    /// Because particle systems are classes rather than structs, we need to make deep
+    /// copies by hand. This is important when creating a secondary system. This method
+    /// copies all values across.
+    @available(*, deprecated, message: "Initialise your VortexSystem with the `settings:` parameter, and this call is no longer needed. ")
+    public func makeUniqueCopy() -> VortexSystem {
+        VortexSystem(
+            tags: vortexSettings.tags,
+            secondarySystems: secondarySystems,
+            spawnOccasion: vortexSettings.spawnOccasion,
+            position: vortexSettings.position,
+            shape: vortexSettings.shape,
+            birthRate: vortexSettings.birthRate,
+            emissionLimit: vortexSettings.emissionLimit,
+            emissionDuration: vortexSettings.emissionDuration,
+            idleDuration: vortexSettings.idleDuration,
+            burstCount: vortexSettings.burstCount,
+            burstCountVariation: vortexSettings.burstCountVariation,
+            lifespan: vortexSettings.lifespan,
+            lifespanVariation: vortexSettings.lifespanVariation,
+            speed: vortexSettings.speed,
+            speedVariation: vortexSettings.speedVariation,
+            angle: vortexSettings.angle,
+            angleRange: vortexSettings.angleRange,
+            acceleration: vortexSettings.acceleration,
+            attractionCenter: vortexSettings.attractionCenter,
+            attractionStrength: vortexSettings.attractionStrength,
+            dampingFactor: vortexSettings.dampingFactor,
+            angularSpeed: vortexSettings.angularSpeed,
+            angularSpeedVariation: vortexSettings.angularSpeedVariation,
+            colors: vortexSettings.colors,
+            size: vortexSettings.size,
+            sizeVariation: vortexSettings.sizeVariation,
+            sizeMultiplierAtDeath: vortexSettings.sizeMultiplierAtDeath,
+            stretchFactor: vortexSettings.stretchFactor
         )
     }
 }

--- a/Sources/Vortex/Views/VortexProxy.swift
+++ b/Sources/Vortex/Views/VortexProxy.swift
@@ -26,7 +26,7 @@ public struct VortexProxy {
     public func move(to newPosition: CGPoint) {
         guard let particleSystem else { return }
 
-        particleSystem.position = [
+        particleSystem.vortexSettings.position = [
             newPosition.x / particleSystem.lastDrawSize.width,
             newPosition.y / particleSystem.lastDrawSize.height
         ]

--- a/Sources/Vortex/Views/VortexView.swift
+++ b/Sources/Vortex/Views/VortexView.swift
@@ -35,7 +35,8 @@ public struct VortexView<Symbols>: View where Symbols: View {
     /// - Parameters:
     ///   - system: The primary particle system you want to render.
     ///   - symbols: A closure that should return one or more SwiftUI views to use as particles. 
-    ///              If a closure is not supplied, a default group of symbols will be provided; tagged with 'circle', 'triangle' and 'sparkle'.
+    ///              If a closure is not supplied, a default group of symbols will be provided; tagged with 'circle', 'confetti' and 'sparkle'.
+    @available(*, deprecated, message: "Deprecated. Invoke the VortexView with a VortexSystem.Settings struct")              
     public init(
         _ system: VortexSystem, 
         targetFrameRate: Int = 60, 
@@ -55,6 +56,32 @@ public struct VortexView<Symbols>: View where Symbols: View {
         self.symbols = symbols()
     }
 
+    /// Creates a new VortexView from a pre-configured particle system, along with any required  SwiftUI
+    /// views needed to render particles. Sensible defaults will be used if no parameters are passed.
+    /// - Parameters:
+    ///   - settings: A vortexSettings struct that should be used to generate a particle system. 
+    ///               Typically this will be set using a preset static struct, e.g. `.fire`. Defaults to a simple system.
+    ///   - targetFrameRate: The ideal frame rate for updating particles. Defaults to 60 if not specified. (use 120 on Pro model iPhones/iPads )
+    ///   - symbols:  A closure that should return a tagged group of SwiftUI views to use as particles. 
+    ///               If not specified, a default group of three views tagged with `.circle`,`.confetti` and `.sparkle` will be used.
+    public init(
+        settings: VortexSystem.Settings = .init(),
+        targetFrameRate: Int = 60, 
+        @ViewBuilder symbols: () -> Symbols = {
+            Group {
+        Image.circle
+            .frame(width: 16).blendMode(.plusLighter).tag("circle")
+        Image.confetti
+            .frame(width: 16, height: 16).blendMode(.plusLighter).tag("triangle") 
+        Image.sparkle
+            .frame(width: 16, height: 16).blendMode(.plusLighter).tag("sparkle") 
+    }
+        }
+    ) {
+        _particleSystem = State( initialValue: VortexSystem(settings: settings) ) 
+        self.targetFrameRate = targetFrameRate
+        self.symbols = symbols()
+    }
     /// Draws one particle system inside the canvas.
     /// - Parameters:
     ///   - particleSystem: The particle system to draw.

--- a/Sources/Vortex/Views/VortexViewReader.swift
+++ b/Sources/Vortex/Views/VortexViewReader.swift
@@ -26,9 +26,9 @@ public struct VortexViewReader<Content: View>: View {
             nearestVortexSystem?.burst()
         } attractTo: { point in
             if let point {
-                nearestVortexSystem?.attractionCenter = SIMD2(point.x, point.y)
+                nearestVortexSystem?.vortexSettings.attractionCenter = SIMD2(point.x, point.y)
             } else {
-                nearestVortexSystem?.attractionCenter = nil
+                nearestVortexSystem?.vortexSettings.attractionCenter = nil
             }
         }
 


### PR DESCRIPTION
This commit looks large, but is essentially just an abstraction of the configuration settings from the VortexSystem into it's own Settings class, with those properties replaced in VortexSystem with a single property; vortexSettings. 

The changes are documented in a the updated README. Settings enables an intuitive initialisation based on preset settings, enables autocomplete for each setting (rather than relying on specifying the required parameters of the init, and getting them all in the right order), and removes the need to ever call `.makeUniqueCopy`.

The change necessitates changes to VortexSystem of course, but also the VortexSystem-Behaviour to ensure that the configuration settings are accessed via vortexSettings. (dynamicLookup is also added to VortexSystem for convenience). 

Included here are also changes to four presets, Confetti, Fire, Fireflies and Fireworks, showing how the settings would be used for each. (A new full width Fire preview is also included showing how preset settings can be tweaked). The others remain (at least for now) with the previous VortexSystem method of initialisation. 
Changing the remainder of the presets would take a matter of moments, however I did not want to update too many files at once! (In the interim, some deprecation warnings will be generated by the compiler - see below)

Because of the changes, and in particular because secondary systems are now secondary settings, this could have been a breaking change. However in the interests of backward compatibility, the old inits have been preserved, although they are now marked as deprecated. 
This will show warnings in the code, but everything will continue to work. 

It is evisaged that after a suitable time, agreed by Paul, the deprecated inits could be removed, and some further code cleanup completed. One such change would be modifying  the init of the VortexView to accept a Settings struct as an anonymous parameter, so that `VortexView(.confetti)` would call the `VortexSystem.Settings.confetti` preset, rather than the current `VortexSystem.confetti` preset, which would be removed.