### PR TITLE
Allow randomRamp particles to use different arrays

### DIFF
--- a/Sources/Vortex/Presets/Magic.swift
+++ b/Sources/Vortex/Presets/Magic.swift
@@ -19,7 +19,15 @@ extension VortexSystem {
             speedVariation: 0.2,
             angleRange: .degrees(360),
             angularSpeedVariation: [0, 0, 10],
-            colors: .random(.red, .pink, .orange, .blue, .green, .white),
+            colors: .randomRamp(
+                [.red, .red, .red.opacity(0)],
+                [.pink, .pink, .pink.opacity(0)],
+                [.orange, .orange, .orange.opacity(0)],
+                [.blue, .blue, .blue.opacity(0)],
+                [.green, .green, .green.opacity(0)],
+                [.white, .white, .white.opacity(0)],
+                preselect: false
+            ),
             size: 0.5,
             sizeVariation: 0.5,
             sizeMultiplierAtDeath: 0.01

--- a/Sources/Vortex/System/ColorMode.swift
+++ b/Sources/Vortex/System/ColorMode.swift
@@ -19,9 +19,11 @@ extension VortexSystem {
         /// Particles should move through an array of colors over time.
         case ramp(_ colors: [Color])
 
-        /// The system should select one random color array, and give that
-        /// to each particle it creates.
-        case randomRamp(_ colors: [[Color]])
+        /// Particles should move through one of several possible color arrays.
+        /// - Parameter preselect: When true, the system will select one random color array,
+        /// and give that to each particle. When false, the system will select a random
+        /// color array for each particle.
+        case randomRamp(_ colors: [[Color]], preselect: Bool = true)
 
         /// A convenience method to create random colors because Swift does not
         /// support variadic enum cases.
@@ -37,8 +39,8 @@ extension VortexSystem {
 
         /// A convenience method to create random color ramps because Swift does not
         /// support variadic enum cases.
-        public static func randomRamp(_ colors: [Color]...) -> ColorMode {
-            .randomRamp(colors)
+        public static func randomRamp(_ colors: [Color]..., preselect: Bool = true) -> ColorMode {
+            .randomRamp(colors, preselect: preselect)
         }
     }
 }

--- a/Sources/Vortex/System/VortexSystem-Behavior.swift
+++ b/Sources/Vortex/System/VortexSystem-Behavior.swift
@@ -227,8 +227,15 @@ extension VortexSystem {
         case .ramp(let colors):
             return colors
 
-        case .randomRamp(let colors):
+        case .randomRamp(let colors, true):
             return colors[selectedColorRamp]
+
+        case .randomRamp(let colors, false):
+            if let randomRamp = colors.randomElement() {
+                return randomRamp
+            } else {
+                return [.white]
+            }
         }
     }
 }

--- a/Sources/Vortex/System/VortexSystem.swift
+++ b/Sources/Vortex/System/VortexSystem.swift
@@ -150,7 +150,7 @@ public class VortexSystem: Codable, Identifiable, Equatable, Hashable {
     /// then this system picks one possible color ramp to use.
     public var colors: ColorMode {
         didSet {
-            if case let .randomRamp(allColors) = colors {
+            if case let .randomRamp(allColors, true) = colors {
                 self.selectedColorRamp = Int.random(in: 0..<allColors.count)
             }
         }
@@ -292,7 +292,7 @@ public class VortexSystem: Codable, Identifiable, Equatable, Hashable {
         self.sizeMultiplierAtDeath = sizeMultiplierAtDeath
         self.stretchFactor = stretchFactor
 
-        if case let .randomRamp(allColors) = colors {
+        if case let .randomRamp(allColors, true) = colors {
             selectedColorRamp = Int.random(in: 0..<allColors.count)
         }
     }


### PR DESCRIPTION
This PR adds a boolean flag to `randomRamp`, allowing the randomization to be per particle.