### PR TITLE
Updated available annotation to fix build errors

### DIFF
--- a/Sources/Vortex/Presets/Confetti.swift
+++ b/Sources/Vortex/Presets/Confetti.swift
@@ -34,7 +34,7 @@ extension VortexSystem {
     ///   - colors: The array of `SwiftUI.Color` to randomize in the confetti.
     ///   - environment: reference to `@Environment(\.self)`
     /// - Returns: an instance of `VortexSystem` to pass into the VortexView
-    @available(macOS 14.0, *)
+    @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
     public static func confetti(
         colors: [SwiftUI.Color],
         in environment: EnvironmentValues


### PR DESCRIPTION
The recently merged pull request #36 has created build errors in the main branch due to missing `available` declarations outside of macOS. This pull requests adds all the required ones to make the project build again.