### PR TITLE
Add `startTimeOffset` to Adjust Animation's Initial State

### DIFF
--- a/Sources/Vortex/Presets/Confetti.swift
+++ b/Sources/Vortex/Presets/Confetti.swift
@@ -34,7 +34,7 @@ extension VortexSystem {
     ///   - colors: The array of `SwiftUI.Color` to randomize in the confetti.
     ///   - environment: reference to `@Environment(\.self)`
     /// - Returns: an instance of `VortexSystem` to pass into the VortexView
-    @available(macOS 14.0, iOS 17, *)
+    @available(macOS 14.0, iOS 17.0, *)
     public static func confetti(
         colors: [SwiftUI.Color],
         in environment: EnvironmentValues

--- a/Sources/Vortex/Presets/Confetti.swift
+++ b/Sources/Vortex/Presets/Confetti.swift
@@ -34,7 +34,7 @@ extension VortexSystem {
     ///   - colors: The array of `SwiftUI.Color` to randomize in the confetti.
     ///   - environment: reference to `@Environment(\.self)`
     /// - Returns: an instance of `VortexSystem` to pass into the VortexView
-    @available(macOS 14.0, *)
+    @available(macOS 14.0, iOS 17, *)
     public static func confetti(
         colors: [SwiftUI.Color],
         in environment: EnvironmentValues

--- a/Sources/Vortex/System/VortexSystem.swift
+++ b/Sources/Vortex/System/VortexSystem.swift
@@ -47,6 +47,9 @@ public class VortexSystem: Codable, Identifiable, Equatable, Hashable {
     /// The last time this particle system was updated.
     var lastUpdate = Date.now.timeIntervalSince1970
 
+    /// The number of seconds to skip forwards (or backwards, if the value is negative) when animation begins.
+    var startTimeOffset: TimeInterval = 0
+
     /// The total number of particles emitted by this system.
     var emissionCount = 0
 
@@ -262,7 +265,8 @@ public class VortexSystem: Codable, Identifiable, Equatable, Hashable {
         size: Double = 1,
         sizeVariation: Double = 0,
         sizeMultiplierAtDeath: Double = 1,
-        stretchFactor: Double = 1
+        stretchFactor: Double = 1,
+        startTimeOffset: TimeInterval = 0
     ) {
         self.tags = tags
         self.secondarySystems = secondarySystems
@@ -292,7 +296,10 @@ public class VortexSystem: Codable, Identifiable, Equatable, Hashable {
         self.sizeVariation = sizeVariation
         self.sizeMultiplierAtDeath = sizeMultiplierAtDeath
         self.stretchFactor = stretchFactor
+        self.startTimeOffset = startTimeOffset
 
+        lastUpdate -= startTimeOffset
+        
         if case let .randomRamp(allColors) = colors {
             selectedColorRamp = Int.random(in: 0..<allColors.count)
         }
@@ -330,7 +337,8 @@ public class VortexSystem: Codable, Identifiable, Equatable, Hashable {
             size: size,
             sizeVariation: sizeVariation,
             sizeMultiplierAtDeath: sizeMultiplierAtDeath,
-            stretchFactor: stretchFactor
+            stretchFactor: stretchFactor,
+            startTimeOffset: startTimeOffset
         )
     }
 }


### PR DESCRIPTION
This addresses #40 by adding a new parameter to `VortexSystem` called `startTimeOffset`. Setting it to a non-zero value will skip the initial state of the particle view's animation forward or backward in time, like `CAEmitterLayer.beginTime`.

(I also had to add an availability check for some `Color` APIs to get Xcode 26 Beta 5 to compile. `.resolve(in:)` and the various `.red/.blue/...` APIs aren't available prior to iOS 17.)